### PR TITLE
fix(generate): update webidl2wit revsion for successful build

### DIFF
--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webidl2wit = { git = "https://github.com/wasi-gfx/webidl2wit.git", rev = "647eddfd72342c3ce523faf8095299851df42536" }
+webidl2wit = { git = "https://github.com/wasi-gfx/webidl2wit.git", rev = "5050df7d3df7415b5628dae44a3cd36fb9efb06f" }
 weedle = "0.13.0"

--- a/generate/Cargo.toml
+++ b/generate/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webidl2wit = { git = "https://github.com/wasi-gfx/webidl2wit.git", rev = "3ad2deea16d938b506ceea935dbcb133f2305ce6" }
+webidl2wit = { git = "https://github.com/wasi-gfx/webidl2wit.git", rev = "647eddfd72342c3ce523faf8095299851df42536" }
 weedle = "0.13.0"


### PR DESCRIPTION
Updated to this revision instead of latest: https://github.com/wasi-gfx/webidl2wit/commit/647eddfd72342c3ce523faf8095299851df42536

Fixes the following:
```rust
Compiling generate v0.1.0 (/Users/kaleb/Development/personal/web-idl/browser.wit/generate)
error[E0308]: mismatched types
  --> browser.wit/generate/src/main.rs:19:29
   |
19 |             interface_name: "global".to_string(),
   |                             ^^^^^^^^^^^^^^^^^^^^ expected `Ident`, found `String`
   |
help: call `Into::into` on this expression to convert `std::string::String` into `webidl2wit::Ident`
   |
19 |             interface_name: "global".to_string().into(),
   |                                                 +++++++

error[E0560]: struct `ConversionOptions` has no field named `phantom_interface`
  --> browser.wit/generate/src/main.rs:21:13
   |
21 |             phantom_interface: [
   |             ^^^^^^^^^^^^^^^^^ `ConversionOptions` does not have this field
   |
   = note: available fields are: `global_singletons`

Some errors have detailed explanations: E0308, E0560.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `generate` (bin "generate") due to 2 previous errors
```

----

The latest revision (https://github.com/wasi-gfx/webidl2wit/commit/18aee776fbf325b094b2ec17bae3ce6f1a71ea51) throws the following:
```bash
   Compiling generate v0.1.0 (/Users/kaleb/Development/personal/web-idl/browser.wit/generate)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `/Users/kaleb/Development/personal/web-idl/target/debug/generate`

Some value: Ident("payment-request-update-event-init")
thread 'main' panicked at webidl2wit/src/translations.rs:419:26:
Base dictionary not found
```

Which is related to the inheritance support changes. 
